### PR TITLE
Add GitHub Actions workflow for Buf module publishing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,17 @@
+name: Publish Buf Module
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  buf-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Buf
+        uses: bufbuild/buf-setup-action@v1
+      - name: Login to Buf
+        run: echo "${{ secrets.BUF_TOKEN }}" | buf registry login --username chinmayb --token-stdin
+      - name: Push to Buf
+        run: buf push

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,6 +1,6 @@
 # https://docs.buf.build/lint-usage/
 version: v1
-name: infoblox.com/infobloxopen/protoc-gen-gorm
+name: buf.build/chinmayb/protoc-gen-gorm
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
- Update buf.yaml module name to buf.build/chinmayb/protoc-gen-gorm
- Add .github/workflows/main.yaml for automated publishing to Buf registry
- Workflow triggers on pushes to main branch and uses BUF_TOKEN secret